### PR TITLE
Attempt to Fix Bug Reported by Andrew

### DIFF
--- a/lobster/core/data/task.py
+++ b/lobster/core/data/task.py
@@ -304,7 +304,7 @@ def check_output(config, localname, remotename):
                 return True
             else:
                 errorMsg = 'size mismatch after transfer\n'
-                errorMsg += '  remote size: {0}\n'.format(match.groups()[0]) 
+                errorMsg += '  remote size: {0}\n'.format(match.groups()[0])
                 errorMsg += '  local size: {0}\n'.format(size)
                 raise RuntimeError(errorMsg)
         else:
@@ -362,10 +362,10 @@ def check_output(config, localname, remotename):
                 "hdfs",
                 "dfs",
                 "-fs",
-                'hdfs://'+server,
+                'hdfs://' + server,
                 "-stat",
                 '"Size: %b"',
-                os.path.join('/',path, remotename)
+                os.path.join('/', path, remotename)
             ]
             p = run_subprocess(args, capture=True)
             try:
@@ -375,7 +375,7 @@ def check_output(config, localname, remotename):
         elif output.startswith('srm://') or output.startswith('gsiftp://'):
             if len(os.environ["LOBSTER_GFAL_COPY"]) > 0:
                 # FIXME gfal is very picky about its environment
-                prg = [os.environ["LOBSTER_GFAL_COPY"].replace('copy','stat')]
+                prg = [os.environ["LOBSTER_GFAL_COPY"].replace('copy', 'stat')]
                 args = prg + [
                     os.path.join(output, remotename),
                 ]
@@ -390,8 +390,6 @@ def check_output(config, localname, remotename):
 
             else:
                 logger.info('Skipping gfal-based file check because no gfal executable defined in wrapper.')
-                
-
 
     # If we get here, we tried all of the other methods and never returned a True, so return false
     return False
@@ -401,7 +399,7 @@ def check_output(config, localname, remotename):
 def check_outputs(data, config):
     logger.info('Checking output files...')
     for local, remote in config['output files']:
-        logger.info('  Checking {0} => {1}'.format(local,remote))
+        logger.info('  Checking {0} => {1}'.format(local, remote))
         if not check_output(config, local, remote):
             raise IOError("could not verify output file '{}'".format(remote))
 
@@ -597,8 +595,8 @@ def copy_inputs(data, config, env):
             elif input.startswith("hdfs://"):
                 logger.info("Trying hdfs client access method")
                 server, path = re.match("hdfs://([a-zA-Z0-9:.\-]+)/(.*)", input).groups()
-                server = "hdfs://"+server
-                remotename = os.path.join('/',path, file)
+                server = "hdfs://" + server
+                remotename = os.path.join('/', path, file)
 
                 timeout = '300'  # Just to be safe, have a timeout
                 args = [
@@ -610,8 +608,7 @@ def copy_inputs(data, config, env):
                     server,
                     "-get",
                     remotename,
-                    os.path.basename(file)
-                    ]
+                    os.path.basename(file)]
                 p = run_subprocess(args, env=env)
                 if p.returncode == 0:
                     logger.info('Successfully copied input with hdfs client')
@@ -769,7 +766,7 @@ def copy_outputs(data, config, env):
                     data['transfers']['chirp']['stageout failure'] += 1
             elif output.startswith("hdfs://"):
                 server, path = re.match("hdfs://([a-zA-Z0-9:.\-]+)/(.*)", output).groups()
-                server = "hdfs://"+server
+                server = "hdfs://" + server
 
                 timeout = '300'  # Just to be safe, have a timeout
                 args = [
@@ -781,8 +778,7 @@ def copy_outputs(data, config, env):
                     server,
                     "-put",
                     localname,
-                    os.path.join('/',path, remotename),
-                    ]
+                    os.path.join('/', path, remotename)]
 
                 p = run_subprocess(args, env=env)
                 logger.info('Checking output file transfer.')

--- a/lobster/core/dataset.py
+++ b/lobster/core/dataset.py
@@ -226,7 +226,7 @@ class MultiProductionDataset(ProductionDataset):
         self.randomize_seeds = randomize_seeds
 
         self.lumis_per_gridpack = int(math.ceil(float(events_per_gridpack) / events_per_lumi))
-        self.total_units = len(flatten(self.gridpacks)) * self.lumis_per_gridpack
+        self.total_untits = 0
 
     def validate(self):
         return len(flatten(self.gridpacks)) > 0
@@ -235,9 +235,11 @@ class MultiProductionDataset(ProductionDataset):
         dset = DatasetInfo()
         dset.file_based = True
 
-        for run, fn in enumerate(flatten(self.gridpacks)):
+        files = flatten(self.gridpacks)
+        for run, fn in enumerate(files):
             dset.files[fn].lumis = [(run, x) for x in range(1, self.lumis_per_gridpack + 1)]
 
+        self.total_units = len(files) * self.lumis_per_gridpack
         dset.total_units = self.total_units
         dset.tasksize = self.lumis_per_task
         dset.stop_on_file_boundary = True  # CMSSW can only handle one gridpack at a time


### PR DESCRIPTION
Andrew reported the following crash in trying to use `MultiProductionDataset` with gridpacks.
```
[.lobster] [klannon@earth test]$ python /afs/crc.nd.edu/user/a/awightma/Public/top_gen.py
Release: /afs/crc.nd.edu/user/a/awightma/Publi
Traceback (most recent call last):
  File "/afs/crc.nd.edu/user/a/awightma/Public/top_gen.py", line 66, in <module>
    randomize_seeds=True
  File "/afs/crc.nd.edu/user/k/klannon/.lobster/lib/python2.7/site-packages/lobster/util.py", line 67, in __call__
    res = type.__call__(cls, *args, **kwargs)
  File "/afs/crc.nd.edu/user/k/klannon/.lobster/lib/python2.7/site-packages/lobster/core/dataset.py", line 229, in __init__
    self.total_units = len(flatten(self.gridpacks)) * self.lumis_per_gridpack
  File "/afs/crc.nd.edu/user/k/klannon/.lobster/lib/python2.7/site-packages/lobster/core/dataset.py", line 44, in flatten
    if fs.isdir(entry):
  File "/afs/crc.nd.edu/user/k/klannon/.lobster/lib/python2.7/site-packages/lobster/se.py", line 59, in switch
    "no resolution found for method '{0}' with arguments '{1}': {2}".format(attr, args, lasterror))
AttributeError: <class 'lobster.core.dataset.MultiProductionDataset'>: no resolution found for method 'isdir' with arguments '('ctG_slc6_amd64_gcc630_CMSSW_9_3_0_tarball.tar.xz',)': None
```

We traced it down (we think) to `MultiProductionDataset` calling
`flatten` in its constructor.  Moved the call to `get_info` to match
pattern used by `Dataset`.

Please make sure that the following items are taken care of if needed:

- [x] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version.
- [x] Did the required _Work Queue_ version change?
  - Please update the *three* version numbers in `doc/install.rst`.  Adjust
    the tarball name in the `install_dependecies.sh` script, too.
- [x] Are all additional dependencies in `setup.py`?
- [x] [Mark any issues as closed either in commits or in this pull
  request.](https://help.github.com/articles/closing-issues-via-commit-messages/)
