### PR TITLE
Better determination of output files.

### DIFF
--- a/lobster/core/data/autosense.sh
+++ b/lobster/core/data/autosense.sh
@@ -5,7 +5,7 @@ pset=$2
 shift
 shift
 
-if [[ $# -ge 1 || -n "$release" || -n "$pset" ]]; then
+if [[ -z "$release" || -z "$pset" ]]; then
 	echo "usage: autosense.sh release pset args..."
 	exit 1
 fi
@@ -13,6 +13,7 @@ fi
 source /cvmfs/cms.cern.ch/cmsset_default.sh 
 cd "$release"
 eval $(scramv1 runtime -sh)
+cd - > /dev/null
 
 python <<EOF
 import imp
@@ -30,12 +31,11 @@ with open('$pset', 'r') as f:
         result['outputs'].append(module.fileName.value().replace('file:', ''))
     if 'TFileService' in process.services:
         result['outputs'].append(process.services['TFileService'].fileName.value().replace('file:', ''))
-         result['merge_command'] = 'hadd'
-         result['merge_args'] = ['@outputfiles', '@inputfiles']
+        result['merge_command'] = 'hadd'
+        result['merge_args'] = ['@outputfiles', '@inputfiles']
 
     if hasattr(process, 'GlobalTag') and hasattr(process.GlobalTag.globaltag, 'value'):
         result['globaltag'] = process.GlobalTag.globaltag.value()
     print(json.dumps(result))
 EOF
 
-rm -rf "$workdir"

--- a/lobster/core/data/autosense.sh
+++ b/lobster/core/data/autosense.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-releas=$1
+release=$1
 pset=$2
 shift
 shift
@@ -11,18 +11,7 @@ if [[ $# -ge 1 || -n "$release" || -n "$pset" ]]; then
 fi
 
 source /cvmfs/cms.cern.ch/cmsset_default.sh 
-workdir=$(mktemp -d)
-cd "$workdir"
-cp $* .
-
-slc=$(egrep "Red Hat Enterprise|Scientific|CentOS" /etc/redhat-release | sed 's/.*[rR]elease \([0-9]*\).*/\1/')
-arch=$(echo sandbox-${version}-slc${slc}*.tar.bz2 |grep -oe "slc${slc}_[^.]*")
-
-export SCRAM_ARCH=$arch
-scramv1 project -f CMSSW $version || exit 1
-tar xjf sandbox-${version}-${arch}.tar.bz2 || exit 1
-
-cd $version
+cd "$release"
 eval $(scramv1 runtime -sh)
 
 python <<EOF

--- a/lobster/core/data/autosense.sh
+++ b/lobster/core/data/autosense.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+releas=$1
+pset=$2
+shift
+shift
+
+if [[ $# -ge 1 || -n "$release" || -n "$pset" ]]; then
+	echo "usage: autosense.sh release pset args..."
+	exit 1
+fi
+
+source /cvmfs/cms.cern.ch/cmsset_default.sh 
+workdir=$(mktemp -d)
+cd "$workdir"
+cp $* .
+
+slc=$(egrep "Red Hat Enterprise|Scientific|CentOS" /etc/redhat-release | sed 's/.*[rR]elease \([0-9]*\).*/\1/')
+arch=$(echo sandbox-${version}-slc${slc}*.tar.bz2 |grep -oe "slc${slc}_[^.]*")
+
+export SCRAM_ARCH=$arch
+scramv1 project -f CMSSW $version || exit 1
+tar xjf sandbox-${version}-${arch}.tar.bz2 || exit 1
+
+cd $version
+eval $(scramv1 runtime -sh)
+
+python <<EOF
+import imp
+import json
+import shlex
+import sys
+
+result = {'outputs': []}
+sys.argv = shlex.split("$*")
+
+with open('$pset', 'r') as f:
+    source = imp.load_source('cms_config_source', '$pset', f)
+    process = source.process
+    for label, module in process.outputModules.items():
+        result['outputs'].append(module.fileName.value().replace('file:', ''))
+    if 'TFileService' in process.services:
+        result['outputs'].append(process.services['TFileService'].fileName.value().replace('file:', ''))
+         result['merge_command'] = 'hadd'
+         result['merge_args'] = ['@outputfiles', '@inputfiles']
+
+    if hasattr(process, 'GlobalTag') and hasattr(process.GlobalTag.globaltag, 'value'):
+        result['globaltag'] = process.GlobalTag.globaltag.value()
+    print(json.dumps(result))
+EOF
+
+rm -rf "$workdir"

--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 import imp
 import json
 import logging
@@ -353,16 +353,19 @@ class Workflow(Configurable):
         for release in releases:
             if not release:
                 continue
-            reldir = lobster.util.findpath(basedirs, release)
+            reldir = util.findpath(basedirs, release)
             cmd = [os.path.join(os.path.dirname(__file__), 'data', 'autosense.sh')]
-            args = [reldir, self.pset, os.path.basename(self.pset)] + self.arguments
+            args = [reldir, os.path.join(self.workdir, os.path.basename(self.pset))] + self.arguments
             try:
-                data = json.loads(subprocess.check_output(cmd + args))
+                result = json.loads(subprocess.check_output(cmd + args))
                 self.outputs = result['outputs']
                 self.merge_command = result.get('merge_command', self.merge_command)
                 self.merge_args = result.get('merge_args', self.merge_args)
                 self.globaltag = result.get('globaltag', self.globaltag)
+                return
             except:
+                e = sys.exc_info()[0:2]
+                logger.info(e)
                 pass
         else:
             raise RuntimeError("failed to autosense output files and/or global tag")
@@ -434,8 +437,8 @@ class Workflow(Configurable):
         self.version = versions.pop()
 
         self.copy_inputs(basedirs)
-        if self.pset and None is in (self.outputs, self.globaltag):
-            self.autosense([getattr(b, 'release', None) for b in boxes])
+        if self.pset and None in (self.outputs, self.globaltag):
+            self.autosense([getattr(b, 'release', None) for b in boxes], basedirs)
 
         # Working directory for workflow
         # TODO Should we really check if this already exists?  IMO that

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'lobster.monitor.elk'
     ],
     package_data={'lobster': [
+        'core/data/autosense.sh',
         'core/data/task.py',
         'core/data/wrapper.sh',
         'core/data/mtab',


### PR DESCRIPTION
A rough draft for a script to automatically determine outputs and
global tags from psets that require a release other than the current
active one. Somehow #634 triggered me to do this, since this has been one of my major pet-peeves all along. Since I'm currently not able to test this, additional work may be required, so maybe this is just a dead end? Feel free to built on top or discard!

This is also just a quick hack; Ideally, there would be a dedicated `cmssw.workflow` module/class that takes care of this in a cleaner way.

Maybe fixes #317 and maybe fixes #634. Additional changes may have to
be applied.

Please make sure that the following items are taken care of if needed:

- [x] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version.
- [x] Did the required _Work Queue_ version change?
  - Please update the *three* version numbers in `doc/install.rst`.  Adjust
    the tarball name in the `install_dependecies.sh` script, too.
- [x] Are all additional dependencies in `setup.py`?
- [x] [Mark any issues as closed either in commits or in this pull
  request.](https://help.github.com/articles/closing-issues-via-commit-messages/)
