### PR TITLE
Fix autosense to include pset name to make VarParsing happy

### DIFF
--- a/lobster/core/data/autosense.sh
+++ b/lobster/core/data/autosense.sh
@@ -27,7 +27,7 @@ import shlex
 import sys
 
 result = {'outputs': []}
-sys.argv = shlex.split("$*")
+sys.argv = ["cmsRun","$pset"] + shlex.split("$*")
 
 with open('$pset', 'r') as f:
     source = imp.load_source('cms_config_source', '$pset', f)


### PR DESCRIPTION
Fixes autosense failing when using a cmsRun config that uses VarParsing.

VarParsing expects the pset name to be in the list of sys.argv (actually it just looks for any element ending in .py) and will fail if the pset is not found. So I added the pset name back to the list of sys.argv as well as included 'cmsRun' in order to be consistent with the way VarParsing gets used.