### PR TITLE
biglib directory added to sandbox

### DIFF
--- a/lobster/cmssw/sandbox.py
+++ b/lobster/cmssw/sandbox.py
@@ -107,7 +107,7 @@ class Sandbox(lobster.core.Sandbox):
         tarball = tarfile.open(outfile, "w|bz2")
 
         # package bin, etc
-        subdirs = ['bin', 'cfipython', 'external', 'lib', 'python']
+        subdirs = ['bin', 'cfipython', 'external', 'lib', 'python', 'biglib']
         subdirs += [os.path.join('src', incl) for incl in self.include]
 
         for (path, dirs, files) in os.walk(os.path.join(indir, 'src')):

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -126,7 +126,7 @@ class StorageElement(object):
         if m:
             protocol, server, path = url_re.match(p).groups()
             path = os.path.normpath(path)
-            return "{0}://{1}{2}/".format(protocol, server, path)
+            return "{0}://{1}{2}".format(protocol, server, path)
         return os.path.normpath(p)
 
     def fixresult(self, res):


### PR DESCRIPTION
Please make sure that the following items are taken care of if needed:

- [ ] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version.
- [ ] Did the required _Work Queue_ version change?
  - Please update the *three* version numbers in `doc/install.rst`.  Adjust
    the tarball name in the `install_dependecies.sh` script, too.
- [ ] Are all additional dependencies in `setup.py`?
- [ ] [Mark any issues as closed either in commits or in this pull
  request.](https://help.github.com/articles/closing-issues-via-commit-messages/)
