### PR TITLE
revert fix for deepthought, add python-daemon fix to the instructions

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -8,7 +8,7 @@ input_path="/store/user/"
 
 storage = StorageConfiguration(
     input=[
-        #"root://deepthought.crc.nd.edu/" + input_path,  # Note the extra slash after the hostname!
+        "root://deepthought.crc.nd.edu/" + input_path,  # Note the extra slash after the hostname!
         "hdfs://eddie.crc.nd.edu:19000"  + input_path,
         "gsiftp://T3_US_NotreDame"       + input_path,
         "srm://T3_US_NotreDame"          + input_path,

--- a/hackathon_instructions.md
+++ b/hackathon_instructions.md
@@ -28,6 +28,7 @@ Next, navigate back to the DBS directory and we will install a couple more packa
 ```
 python setup.py install_system -s dbs-client
 python setup.py install_system -s pycurl-client
+conda install -c conda-forge python-daemon
 ```
 
 Then, navigate back to the cloned lobster directory (probably `cd ../lobster/`) and run the following command: 


### PR DESCRIPTION
Please make sure that the following items are taken care of if needed:

- [ ] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version.
- [ ] Did the required _Work Queue_ version change?
  - Please update the *three* version numbers in `doc/install.rst`.  Adjust
    the tarball name in the `install_dependecies.sh` script, too.
- [ ] Are all additional dependencies in `setup.py`?
- [ ] [Mark any issues as closed either in commits or in this pull
  request.](https://help.github.com/articles/closing-issues-via-commit-messages/)
