### PR TITLE
fix paths to /store/user/$USER

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -4,20 +4,19 @@ from lobster import cmssw
 from lobster.core import AdvancedOptions, Category, Config, Dataset, ParentDataset, StorageConfiguration, Workflow
 
 version = datetime.datetime.now().strftime('%Y%m%d_%H%M')
-#input_path="/store/user/"
-input_path = "/data/users/"
+input_path = "/store/user"
 
 storage = StorageConfiguration(
     input=[
-        "root://disc-head-001.crc.nd.edu//data/users/",
+        "root://disc-head-001.crc.nd.edu/" + input_path,
         #"root://hactar01.crc.nd.edu//data/users/",
         #"file:///cms/cephfs/data/users/",
         #"root://deepthought.crc.nd.edu/" + input_path,  # Note the extra slash after the hostname!
     ],
     output=[
         # Until a separate bug is fixed file://cms/cephfs needs to be the first output so the initial lobster validation passes. 
-        "file:///cms/cephfs/data/users/$USER/lobster_test/" + version,
-        "root://disc-head-001.crc.nd.edu//data/users/hnelson2/lobster_test/"+version,
+        "file:///cms/cephfs/data/store/user/$USER/lobster_test/" + version,
+        "root://disc-head-001.crc.nd.edu//store/user/$USER/lobster_test/"+version,
         #"root://hactar01.crc.nd.edu//data/users/hnelson2/lobster_test/"+version,
         # ND is not in the XrootD redirector, thus hardcode server.
         # Note the double-slash after the hostname!


### PR DESCRIPTION
Please make sure that the following items are taken care of if needed:

- [ ] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version.
- [ ] Did the required _Work Queue_ version change?
  - Please update the *three* version numbers in `doc/install.rst`.  Adjust
    the tarball name in the `install_dependecies.sh` script, too.
- [ ] Are all additional dependencies in `setup.py`?
- [ ] [Mark any issues as closed either in commits or in this pull
  request.](https://help.github.com/articles/closing-issues-via-commit-messages/)
