### PR TITLE
remove leftover srm else case

### DIFF
--- a/lobster/core/data/task.py
+++ b/lobster/core/data/task.py
@@ -583,8 +583,6 @@ def copy_outputs(data, config, env):
                     except Exception as e:
                         logger.critical(e)
                         data['transfers']['file']['stageout failure'] += 1
-                else:
-                    data['transfers'][protocol]['failure'] += 1
             elif output.startswith("root://"):
                 args = [
                     "env",


### PR DESCRIPTION
Please make sure that the following items are taken care of if needed:

- [ ] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version.
- [ ] Did the required _Work Queue_ version change?
  - Please update the *three* version numbers in `doc/install.rst`.  Adjust
    the tarball name in the `install_dependecies.sh` script, too.
- [ ] Are all additional dependencies in `setup.py`?
- [ ] [Mark any issues as closed either in commits or in this pull
  request.](https://help.github.com/articles/closing-issues-via-commit-messages/)
