### PR TITLE
Wmcore disable source load config during py2 to py3 transition

### DIFF
--- a/lobster/core/data/task.py
+++ b/lobster/core/data/task.py
@@ -24,7 +24,6 @@ sys.path.append('python')
 
 from WMCore.DataStructs.LumiList import LumiList
 from WMCore.FwkJobReport.Report import Report
-from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig
 
 import ROOT
 

--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -18,7 +18,18 @@ from lobster.core import unit
 from lobster.core import Algo
 from lobster.core import MergeTaskHandler
 
-from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig, SiteConfigError
+
+# disable site config during py2 to py3 transition
+enable_wmcore = False
+if enable_wmcore:
+    from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig, SiteConfigError
+else:
+    class SiteConfigError(Exception):
+        pass
+
+    def loadSiteLocalConfig(*args, **kwargs):
+        raise SiteConfigError()
+
 
 logger = logging.getLogger('lobster.source')
 


### PR DESCRIPTION
Please make sure that the following items are taken care of if needed:

- [ ] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version.
- [ ] Did the required _Work Queue_ version change?
  - Please update the *three* version numbers in `doc/install.rst`.  Adjust
    the tarball name in the `install_dependecies.sh` script, too.
- [ ] Are all additional dependencies in `setup.py`?
- [ ] [Mark any issues as closed either in commits or in this pull
  request.](https://help.github.com/articles/closing-issues-via-commit-messages/)
