### PR TITLE
fix:  Change math in directory name creation for python3.

### DIFF
--- a/lobster/util.py
+++ b/lobster/util.py
@@ -18,7 +18,7 @@ import shutil
 import smtplib
 import subprocess
 import time
-
+import math
 from contextlib import contextmanager
 from email.mime.text import MIMEText
 from pkg_resources import get_distribution
@@ -318,7 +318,8 @@ def id2dir(id):
     # only.
     id = int(id)
     man = str(id % 10000).zfill(4)
-    oku = str(id / 10000).zfill(4)
+    #oku = str(id / 10000).zfill(4)
+    oku = str(math.floor(id / 10000)).zfill(4)  # python3 fix, oku should be 0000 until 10000 jobs, then 0001, etc...
     return os.path.join(oku, man)
 
 


### PR DESCRIPTION
Please make sure that the following items are taken care of if needed:

- [ ] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version.
- [ ] Did the required _Work Queue_ version change?
  - Please update the *three* version numbers in `doc/install.rst`.  Adjust
    the tarball name in the `install_dependecies.sh` script, too.
- [ ] Are all additional dependencies in `setup.py`?
- [ ] [Mark any issues as closed either in commits or in this pull
  request.](https://help.github.com/articles/closing-issues-via-commit-messages/)
