### PR TITLE
move pip install of wmcore after conda activate

### DIFF
--- a/hackathon_instructions.md
+++ b/hackathon_instructions.md
@@ -14,19 +14,21 @@ unset PYTHONPATH
 mkdir lobster-python3
 cd lobster-python3
 
-git clone git@github.com:dmwm/WMCore.git --branch 2.3.5
-cd WMCore
-sed -i -E '/^(gfal2|htcondor|kkmysqlclient|rucio-clients|Sphinx|coverage|memory-profiler|mox3|nose|nose2|pycodestyle|pylint|pymongo)/d' requirements.txt
-pip install -r requirements.txt .
-
-cd ..  # back to lobster-python3/
-
 git clone https://github.com/NDCMS/lobster.git
 cd lobster
 git checkout lobster-python3
 
 conda env create -f lobster_env.yaml -n lobster
 conda activate lobster
+
+cd ..  # back to lobster-python3/
+
+git clone git@github.com:dmwm/WMCore.git --branch 2.3.5
+cd WMCore
+sed -i -E '/^(gfal2|htcondor|kkmysqlclient|rucio-clients|Sphinx|coverage|memory-profiler|mox3|nose|nose2|pycodestyle|pylint|pymongo)/d' requirements.txt
+pip install -r requirements.txt .
+
+cd ../lobster   # to lobster-python3/lobster
 ```
 
 **Note:** The yaml file and the above command creates an environment named `lobster`,  


### PR DESCRIPTION
Please make sure that the following items are taken care of if needed:

- [ ] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version.
- [ ] Did the required _Work Queue_ version change?
  - Please update the *three* version numbers in `doc/install.rst`.  Adjust
    the tarball name in the `install_dependecies.sh` script, too.
- [ ] Are all additional dependencies in `setup.py`?
- [ ] [Mark any issues as closed either in commits or in this pull
  request.](https://help.github.com/articles/closing-issues-via-commit-messages/)
