### PR TITLE
Install future/pip to resolve WMCore dependencies

### DIFF
--- a/lobster/core/data/wrapper.sh
+++ b/lobster/core/data/wrapper.sh
@@ -161,6 +161,9 @@ date +%s > t_wrapper_ready
 
 log "dir" "working directory before execution" ls -l
 
+python -m ensurepip --user
+python -m pip install --user future
+
 $*
 res=$?
 


### PR DESCRIPTION
Workflows with older releases will fail with the following error:
```python
Traceback (most recent call last):
  File "task.py", line 25, in <module>
    from WMCore.DataStructs.LumiList import LumiList
  File "/var/condor/execute/dir_1250335/worker-238761-1250367/t.3/python/WMCore/DataStructs/LumiList.py", line 16, in <module>
    from builtins import zip, range, next, str, object
ImportError: No module named builtins
```
The solution is to install the `future` package. Some older releases do not have pip so this also needs to be installed.
