### PR TITLE
fixing bugs for running lobster jobs in el9

### DIFF
--- a/lobster/cmssw/sandbox.py
+++ b/lobster/cmssw/sandbox.py
@@ -67,6 +67,8 @@ class Sandbox(lobster.core.Sandbox):
     def _get_cmssw_arch(self, dirname):
         candidates = glob.glob('{}/.SCRAM/slc*'.format(dirname))
         if len(candidates) != 1:
+            candidates = glob.glob('{}/.SCRAM/el*'.format(dirname))
+        if len(candidates) != 1:
             raise AttributeError("Can't determine SCRAM arch!")
         return os.path.basename(candidates[0])
 

--- a/lobster/core/data/autosense.sh
+++ b/lobster/core/data/autosense.sh
@@ -20,7 +20,7 @@ cd "$release"
 eval $(scramv1 runtime -sh)
 cd - > /dev/null
 
-python <<EOF > /dev/null 2>&1
+python3 <<EOF > /dev/null 2>&1
 import imp
 import json
 import shlex

--- a/lobster/core/data/task.py
+++ b/lobster/core/data/task.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from collections import defaultdict, Counter
 from contextlib import contextmanager
@@ -54,7 +54,7 @@ class Mangler(logging.Formatter):
             fmt = '{chevron} {context}: {message}'
         else:
             fmt = '{chevron} {message}'
-        chevron = '>' * (record.levelno / logging.DEBUG + 1)
+        chevron = '>' * int(record.levelno / logging.DEBUG + 1)
         return fmt.format(chevron=chevron, message=record.msg, date=time.strftime("%c"), context=self.context)
 
 

--- a/lobster/core/data/wrapper.sh
+++ b/lobster/core/data/wrapper.sh
@@ -126,8 +126,10 @@ fi
 log "sourcing CMS setup"
 source /cvmfs/cms.cern.ch/cmsset_default.sh || exit_on_error $? 175 "Failed to source CMS"
 
-slc=$(egrep "Red Hat Enterprise|Scientific|CentOS" /etc/redhat-release | sed 's/.*[rR]elease \([0-9]*\).*/\1/')
-arch=$(echo sandbox-${LOBSTER_CMSSW_VERSION}-slc${slc}*.tar.bz2 | grep -oe "slc${slc}_[^.]*")
+slc=$(sed -n 's/.*[Rr]elease \([0-9][0-9]*\).*/\1/p' /etc/redhat-release)
+arch=$(echo sandbox-${LOBSTER_CMSSW_VERSION}-el${slc}_*.tar.bz2 | grep -oe "el${slc}_[^.]*")
+#slc=$(egrep "Red Hat Enterprise|Scientific|CentOS" /etc/redhat-release | sed 's/.*[rR]elease \([0-9]*\).*/\1/')
+#arch=$(echo sandbox-${LOBSTER_CMSSW_VERSION}-slc${slc}*.tar.bz2 | grep -oe "slc${slc}_[^.]*")
 
 if [ -z "$LOBSTER_PROXY_INFO" -o \( -z "$LOBSTER_LCG_CP" -a -z "$LOBSTER_GFAL_COPY" \) ]; then
 	log "sourcing OSG setup"
@@ -161,8 +163,10 @@ date +%s > t_wrapper_ready
 
 log "dir" "working directory before execution" ls -l
 
-python -m ensurepip --user
-python -m pip install --user future
+python3 -m ensurepip --user
+python3 -m pip install --user future
+
+echo "Command to be executed: $*"
 
 $*
 res=$?
@@ -171,5 +175,7 @@ log "dir" "working directory after execution" ls -l
 
 log "wrapper done"
 log "final return status = $res"
+
+echo "Command finished with status $res"
 
 exit $res

--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -360,7 +360,7 @@ class TaskProvider(util.Timing):
                 'gridpack': False
             }
 
-            cmd = 'sh wrapper.sh python task.py parameters.json'
+            cmd = 'sh wrapper.sh python3 task.py parameters.json'
             env = {
                 'LOBSTER_CVMFS_PROXY': self.__cvmfs_proxy,
                 'LOBSTER_FRONTIER_PROXY': self.__frontier_proxy,


### PR DESCRIPTION
Ben’s recommendations were:

Run Lobster for Python 3

I installed the [lobster-python3 branch](https://github.com/NDCMS/lobster/blob/lobster-python3/hackathon_instructions.md).

Use the correct CCTools

export PATH="/afs/[crc.nd.edu/group/ccl/software/x86_64/redhat9/cctools/current/bin:$PATH](http://crc.nd.edu/group/ccl/software/x86_64/redhat9/cctools/current/bin:$PATH)"


Run the correct factory

--runos rh9-wq-prot-11




With these changes, my jobs were submitted successfully. I also had to make a few fixes to the Lobster package itself:

SCRAM directory detection

Update [sandbox.py:L68](https://github.com/NDCMS/lobster/blob/lobster-python3/lobster/cmssw/sandbox.py#L68):

def _get_cmssw_arch(self, dirname):
    candidates = glob.glob('{}/.SCRAM/slc*'.format(dirname))
    if len(candidates) != 1:
        candidates = glob.glob('{}/.SCRAM/el*'.format(dirname))
    if len(candidates) != 1:
        raise AttributeError("Can't determine SCRAM arch!")
    return os.path.basename(candidates[0])


CVMFS source

Modify [wrapper.sh:L129](https://github.com/NDCMS/lobster/blob/lobster-python3/lobster/core/data/wrapper.sh#L129):

slc=$(sed -n 's/.*[Rr]elease \([0-9][0-9]*\).*/\1/p' /etc/redhat-release)
arch=$(echo sandbox-${LOBSTER_CMSSW_VERSION}-el${slc}_*.tar.bz2 | grep -oe "el${slc}_[^.]*")


Python command

On EL9, python is not defined. I replaced calls to python with python3 in:

[wrapper.sh:L164](https://github.com/NDCMS/lobster/blob/lobster-python3/lobster/core/data/wrapper.sh#L164)

[source.py:L363](https://github.com/NDCMS/lobster/blob/lobster-python3/lobster/core/source.py#L363)

Logging formatter fix

In [task.py:L57](https://github.com/NDCMS/lobster/blob/lobster-python3/lobster/core/data/task.py#L57), update to:

chevron = '>' * int(record.levelno / logging.DEBUG + 1)